### PR TITLE
Refactor for Issue37

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 src/**/*.js
 test/**/*.js
 lib/
+.node-version

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@textlint/types": "^1.3.1",
     "@types/jest": "^25.1.3",
     "@types/node": "^13.7.7",
-    "@types/parsimmon": "^1.10.1",
     "@typescript-eslint/eslint-plugin": "^2.22.0",
     "@typescript-eslint/parser": "^2.22.0",
     "eslint": "^6.8.0",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
   "license": "GPL-3.0-or-later",
   "dependencies": {
     "@textlint/ast-node-types": "^4.2.5",
-    "latex-utensils": "^2.0.0-beta.4",
-    "traverse": "^0.6.6"
+    "latex-utensils": "^2.0.0-beta.4"
   },
   "devDependencies": {
     "@textlint/ast-tester": "^2.1.6",
@@ -30,7 +29,6 @@
     "@types/jest": "^25.1.3",
     "@types/node": "^13.7.7",
     "@types/parsimmon": "^1.10.1",
-    "@types/traverse": "^0.6.32",
     "@typescript-eslint/eslint-plugin": "^2.22.0",
     "@typescript-eslint/parser": "^2.22.0",
     "eslint": "^6.8.0",

--- a/src/LaTeXProcessor.ts
+++ b/src/LaTeXProcessor.ts
@@ -29,9 +29,9 @@ export class LaTeXProcessor implements TextlintPluginProcessor {
   public availableExtensions(): string[] {
     return [".tex", ".cls"].concat(this.config.extensions || []);
   }
-  public processor(extension: string) {
+  public processor() {
     return {
-      preProcess(text: string, filePath?: string): TxtParentNode {
+      preProcess(text: string): TxtParentNode {
         return parse(text);
       },
       postProcess(messages: any[], filePath?: string) {

--- a/src/latex-to-ast.ts
+++ b/src/latex-to-ast.ts
@@ -69,8 +69,8 @@ const complete = (text: string, node: TxtParentNode): TxtParentNode => {
       node.children[i].range[1],
       node.children[i + 1].range[0]
     ];
+    children.push(node.children[i]);
     if (range[0] !== range[1]) {
-      children.push(node.children[i]);
       children.push({
         loc: {
           start: caculatePosition(text, range[0]),
@@ -106,296 +106,415 @@ export const parse = (text: string): TxtParentNode => {
     children: ast.content
       .map(function transform(
         node: latexParser.Node
-      ): TxtTextNode | TxtNode | null {
+      ): (TxtTextNode | TxtNode)[] {
         switch (node.kind) {
           case "command":
             switch (node.name) {
               case "textbf":
-                return {
-                  loc: {
-                    start: {
-                      line: node.location.start.line,
-                      column: node.location.start.column - 1
+                return [
+                  {
+                    loc: {
+                      start: {
+                        line: node.location.start.line,
+                        column: node.location.start.column - 1
+                      },
+                      end: {
+                        line: node.location.end.line,
+                        column: node.location.end.column - 1
+                      }
                     },
-                    end: {
-                      line: node.location.end.line,
-                      column: node.location.end.column - 1
-                    }
-                  },
-                  range: [node.location.start.offset, node.location.end.offset],
-                  raw: text.slice(
-                    node.location.start.offset,
-                    node.location.end.offset
-                  ),
-                  type: ASTNodeTypes.Strong,
-                  children: node.args.map(transform).filter(n => n !== null)
-                };
+                    range: [
+                      node.location.start.offset,
+                      node.location.end.offset
+                    ],
+                    raw: text.slice(
+                      node.location.start.offset,
+                      node.location.end.offset
+                    ),
+                    type: ASTNodeTypes.Strong,
+                    children: node.args
+                      .map(transform)
+                      .reduce((a, b) => [...a, ...b], [])
+                  }
+                ];
               case "textit":
-                return {
-                  loc: {
-                    start: {
-                      line: node.location.start.line,
-                      column: node.location.start.column - 1
+                return [
+                  {
+                    loc: {
+                      start: {
+                        line: node.location.start.line,
+                        column: node.location.start.column - 1
+                      },
+                      end: {
+                        line: node.location.end.line,
+                        column: node.location.end.column - 1
+                      }
                     },
-                    end: {
-                      line: node.location.end.line,
-                      column: node.location.end.column - 1
-                    }
-                  },
-                  range: [node.location.start.offset, node.location.end.offset],
-                  raw: text.slice(
-                    node.location.start.offset,
-                    node.location.end.offset
-                  ),
-                  type: ASTNodeTypes.Emphasis,
-                  children: node.args.map(transform).filter(n => n !== null)
-                };
+                    range: [
+                      node.location.start.offset,
+                      node.location.end.offset
+                    ],
+                    raw: text.slice(
+                      node.location.start.offset,
+                      node.location.end.offset
+                    ),
+                    type: ASTNodeTypes.Emphasis,
+                    children: node.args
+                      .map(transform)
+                      .reduce((a, b) => [...a, ...b], [])
+                  }
+                ];
               case "institute":
               case "title":
               case "author":
+                return [
+                  {
+                    loc: {
+                      start: {
+                        line: node.location.start.line,
+                        column: node.location.start.column - 1
+                      },
+                      end: {
+                        line: node.location.end.line,
+                        column: node.location.end.column - 1
+                      }
+                    },
+                    range: [
+                      node.location.start.offset,
+                      node.location.end.offset
+                    ],
+                    raw: text.slice(
+                      node.location.start.offset,
+                      node.location.end.offset
+                    ),
+                    type: ASTNodeTypes.Header,
+                    children: node.args
+                      .map(transform)
+                      .reduce((a, b) => [...a, ...b], [])
+                  }
+                ];
               case "chapter":
-                return {
-                  depth: 1,
-                  loc: {
-                    start: {
-                      line: node.location.start.line,
-                      column: node.location.start.column - 1
+                return [
+                  {
+                    depth: 1,
+                    loc: {
+                      start: {
+                        line: node.location.start.line,
+                        column: node.location.start.column - 1
+                      },
+                      end: {
+                        line: node.location.end.line,
+                        column: node.location.end.column - 1
+                      }
                     },
-                    end: {
-                      line: node.location.end.line,
-                      column: node.location.end.column - 1
-                    }
-                  },
-                  range: [node.location.start.offset, node.location.end.offset],
-                  raw: text.slice(
-                    node.location.start.offset,
-                    node.location.end.offset
-                  ),
-                  type: ASTNodeTypes.Header,
-                  children: node.args.map(transform).filter(n => n !== null)
-                };
+                    range: [
+                      node.location.start.offset,
+                      node.location.end.offset
+                    ],
+                    raw: text.slice(
+                      node.location.start.offset,
+                      node.location.end.offset
+                    ),
+                    type: ASTNodeTypes.Header,
+                    children: node.args
+                      .map(transform)
+                      .reduce((a, b) => [...a, ...b], [])
+                  }
+                ];
               case "section":
-                return {
-                  depth: 2,
-                  loc: {
-                    start: {
-                      line: node.location.start.line,
-                      column: node.location.start.column - 1
+                return [
+                  {
+                    depth: 2,
+                    loc: {
+                      start: {
+                        line: node.location.start.line,
+                        column: node.location.start.column - 1
+                      },
+                      end: {
+                        line: node.location.end.line,
+                        column: node.location.end.column - 1
+                      }
                     },
-                    end: {
-                      line: node.location.end.line,
-                      column: node.location.end.column - 1
-                    }
-                  },
-                  range: [node.location.start.offset, node.location.end.offset],
-                  raw: text.slice(
-                    node.location.start.offset,
-                    node.location.end.offset
-                  ),
-                  type: ASTNodeTypes.Header,
-                  children: node.args.map(transform).filter(n => n !== null)
-                };
+                    range: [
+                      node.location.start.offset,
+                      node.location.end.offset
+                    ],
+                    raw: text.slice(
+                      node.location.start.offset,
+                      node.location.end.offset
+                    ),
+                    type: ASTNodeTypes.Header,
+                    children: node.args
+                      .map(transform)
+                      .reduce((a, b) => [...a, ...b], [])
+                  }
+                ];
               case "subsection":
-                return {
-                  depth: 3,
-                  loc: {
-                    start: {
-                      line: node.location.start.line,
-                      column: node.location.start.column - 1
+                return [
+                  {
+                    depth: 3,
+                    loc: {
+                      start: {
+                        line: node.location.start.line,
+                        column: node.location.start.column - 1
+                      },
+                      end: {
+                        line: node.location.end.line,
+                        column: node.location.end.column - 1
+                      }
                     },
-                    end: {
-                      line: node.location.end.line,
-                      column: node.location.end.column - 1
-                    }
-                  },
-                  range: [node.location.start.offset, node.location.end.offset],
-                  raw: text.slice(
-                    node.location.start.offset,
-                    node.location.end.offset
-                  ),
-                  type: ASTNodeTypes.Header,
-                  children: node.args.map(transform).filter(n => n !== null)
-                };
+                    range: [
+                      node.location.start.offset,
+                      node.location.end.offset
+                    ],
+                    raw: text.slice(
+                      node.location.start.offset,
+                      node.location.end.offset
+                    ),
+                    type: ASTNodeTypes.Header,
+                    children: node.args
+                      .map(transform)
+                      .reduce((a, b) => [...a, ...b], [])
+                  }
+                ];
               case "subsubsection":
-                return {
-                  depth: 4,
-                  loc: {
-                    start: {
-                      line: node.location.start.line,
-                      column: node.location.start.column - 1
+                return [
+                  {
+                    depth: 4,
+                    loc: {
+                      start: {
+                        line: node.location.start.line,
+                        column: node.location.start.column - 1
+                      },
+                      end: {
+                        line: node.location.end.line,
+                        column: node.location.end.column - 1
+                      }
                     },
-                    end: {
-                      line: node.location.end.line,
-                      column: node.location.end.column - 1
-                    }
-                  },
-                  range: [node.location.start.offset, node.location.end.offset],
-                  raw: text.slice(
-                    node.location.start.offset,
-                    node.location.end.offset
-                  ),
-                  type: ASTNodeTypes.Header,
-                  children: node.args.map(transform).filter(n => n !== null)
-                };
+                    range: [
+                      node.location.start.offset,
+                      node.location.end.offset
+                    ],
+                    raw: text.slice(
+                      node.location.start.offset,
+                      node.location.end.offset
+                    ),
+                    type: ASTNodeTypes.Header,
+                    children: node.args
+                      .map(transform)
+                      .reduce((a, b) => [...a, ...b], [])
+                  }
+                ];
               default:
-                return null;
+                return [];
             }
           case "command.text":
-            return {
-              loc: {
-                start: {
-                  line: node.location.start.line,
-                  column: node.location.start.column - 1
+            return [
+              {
+                loc: {
+                  start: {
+                    line: node.location.start.line,
+                    column: node.location.start.column - 1
+                  },
+                  end: {
+                    line: node.location.end.line,
+                    column: node.location.end.column - 1
+                  }
                 },
-                end: {
-                  line: node.location.end.line,
-                  column: node.location.end.column - 1
-                }
-              },
-              range: [node.location.start.offset, node.location.end.offset],
-              raw: text.slice(
-                node.location.start.offset,
-                node.location.end.offset
-              ),
-              type: ASTNodeTypes.Paragraph,
-              children: [node.arg].map(transform).filter(n => n !== null)
-            };
+                range: [node.location.start.offset, node.location.end.offset],
+                raw: text.slice(
+                  node.location.start.offset,
+                  node.location.end.offset
+                ),
+                type: ASTNodeTypes.Str,
+                children: transform(node.arg)
+              }
+            ];
           case "env":
             switch (node.name) {
+              case "document":
+                return node.content
+                  .map(transform)
+                  .reduce((a, b) => [...a, ...b], []);
               default:
-                return {
-                  loc: {
-                    start: {
-                      line: node.location.start.line,
-                      column: node.location.start.column - 1
+                return [
+                  {
+                    loc: {
+                      start: {
+                        line: node.location.start.line,
+                        column: node.location.start.column - 1
+                      },
+                      end: {
+                        line: node.location.end.line,
+                        column: node.location.end.column - 1
+                      }
                     },
-                    end: {
-                      line: node.location.end.line,
-                      column: node.location.end.column - 1
-                    }
-                  },
-                  range: [node.location.start.offset, node.location.end.offset],
-                  raw: text.slice(
-                    node.location.start.offset,
-                    node.location.end.offset
-                  ),
-                  type: ASTNodeTypes.Paragraph,
-                  children: [...node.args, ...node.content]
-                    .map(transform)
-                    .filter(n => n !== null)
-                };
+                    range: [
+                      node.location.start.offset,
+                      node.location.end.offset
+                    ],
+                    raw: text.slice(
+                      node.location.start.offset,
+                      node.location.end.offset
+                    ),
+                    type: ASTNodeTypes.Paragraph,
+                    children: [...node.args, ...node.content]
+                      .map(transform)
+                      .reduce((a, b) => [...a, ...b], [])
+                  }
+                ];
             }
           case "env.lstlisting":
           case "env.verbatim":
           case "env.minted":
-            return {
-              loc: {
-                start: {
-                  line: node.location.start.line,
-                  column: node.location.start.column - 1
+            return [
+              {
+                loc: {
+                  start: {
+                    line: node.location.start.line,
+                    column: node.location.start.column - 1
+                  },
+                  end: {
+                    line: node.location.end.line,
+                    column: node.location.end.column - 1
+                  }
                 },
-                end: {
-                  line: node.location.end.line,
-                  column: node.location.end.column - 1
-                }
-              },
-              range: [node.location.start.offset, node.location.end.offset],
-              raw: text.slice(
-                node.location.start.offset,
-                node.location.end.offset
-              ),
-              type: ASTNodeTypes.CodeBlock,
-              value: node.content
-            };
+                range: [node.location.start.offset, node.location.end.offset],
+                raw: text.slice(
+                  node.location.start.offset,
+                  node.location.end.offset
+                ),
+                type: ASTNodeTypes.CodeBlock,
+                value: node.content
+              }
+            ];
           case "env.math.align":
           case "env.math.aligned":
           case "displayMath":
-            return {
-              loc: {
-                start: {
-                  line: node.location.start.line,
-                  column: node.location.start.column - 1
+            return [
+              {
+                loc: {
+                  start: {
+                    line: node.location.start.line,
+                    column: node.location.start.column - 1
+                  },
+                  end: {
+                    line: node.location.end.line,
+                    column: node.location.end.column - 1
+                  }
                 },
-                end: {
-                  line: node.location.end.line,
-                  column: node.location.end.column - 1
-                }
-              },
-              range: [node.location.start.offset, node.location.end.offset],
-              raw: text.slice(
-                node.location.start.offset,
-                node.location.end.offset
-              ),
-              value: latexParser.stringify(node.content),
-              type: ASTNodeTypes.CodeBlock
-            };
+                range: [node.location.start.offset, node.location.end.offset],
+                raw: text.slice(
+                  node.location.start.offset,
+                  node.location.end.offset
+                ),
+                value: text.slice(
+                  node.content[0].location?.start.offset,
+                  node.content[node.content.length - 1].location?.end.offset
+                ),
+                type: ASTNodeTypes.CodeBlock
+              }
+            ];
           case "superscript":
           case "subscript":
-            return {
-              loc: {
-                start: {
-                  line: node.location.start.line,
-                  column: node.location.start.column - 1
+            return [
+              {
+                loc: {
+                  start: {
+                    line: node.location.start.line,
+                    column: node.location.start.column - 1
+                  },
+                  end: {
+                    line: node.location.end.line,
+                    column: node.location.end.column - 1
+                  }
                 },
-                end: {
-                  line: node.location.end.line,
-                  column: node.location.end.column - 1
-                }
-              },
-              range: [node.location.start.offset, node.location.end.offset],
-              raw: text.slice(
-                node.location.start.offset,
-                node.location.end.offset
-              ),
-              type: ASTNodeTypes.Code,
-              children: [node.arg]
-                .map(n => (n !== undefined ? transform(n) : null))
-                .filter(n => n !== null)
-            };
+                range: [node.location.start.offset, node.location.end.offset],
+                raw: text.slice(
+                  node.location.start.offset,
+                  node.location.end.offset
+                ),
+                type: ASTNodeTypes.Code,
+                children: node.arg === undefined ? [] : transform(node.arg)
+              }
+            ];
           case "inlineMath":
           case "math.math_delimiters":
           case "math.matching_delimiters":
-            return {
-              loc: {
-                start: {
-                  line: node.location.start.line,
-                  column: node.location.start.column - 1
+            return [
+              {
+                loc: {
+                  start: {
+                    line: node.location.start.line,
+                    column: node.location.start.column - 1
+                  },
+                  end: {
+                    line: node.location.end.line,
+                    column: node.location.end.column - 1
+                  }
                 },
-                end: {
-                  line: node.location.end.line,
-                  column: node.location.end.column - 1
-                }
-              },
-              range: [node.location.start.offset, node.location.end.offset],
-              raw: text.slice(
-                node.location.start.offset,
-                node.location.end.offset
-              ),
-              value: latexParser.stringify(node.content),
-              type: ASTNodeTypes.Code
-            };
+                range: [node.location.start.offset, node.location.end.offset],
+                raw: text.slice(
+                  node.location.start.offset,
+                  node.location.end.offset
+                ),
+                value: text.slice(
+                  node.content[0].location?.start.offset,
+                  node.content[node.content.length - 1].location?.end.offset
+                ),
+                type: ASTNodeTypes.Code
+              }
+            ];
           case "verb":
-            return {
-              loc: {
-                start: {
-                  line: node.location.start.line,
-                  column: node.location.start.column - 1
+            return [
+              {
+                loc: {
+                  start: {
+                    line: node.location.start.line,
+                    column: node.location.start.column - 1
+                  },
+                  end: {
+                    line: node.location.end.line,
+                    column: node.location.end.column - 1
+                  }
                 },
-                end: {
-                  line: node.location.end.line,
-                  column: node.location.end.column - 1
-                }
-              },
-              range: [node.location.start.offset, node.location.end.offset],
-              raw: text.slice(
-                node.location.start.offset,
-                node.location.end.offset
-              ),
-              type: ASTNodeTypes.Code,
-              value: node.content
-            };
+                range: [node.location.start.offset, node.location.end.offset],
+                raw: text.slice(
+                  node.location.start.offset,
+                  node.location.end.offset
+                ),
+                type: ASTNodeTypes.Code,
+                value: node.content
+              }
+            ];
           case "text.string":
-            return {
+            return [
+              {
+                loc: {
+                  start: {
+                    line: node.location.start.line,
+                    column: node.location.start.column - 1
+                  },
+                  end: {
+                    line: node.location.end.line,
+                    column: node.location.end.column - 1
+                  }
+                },
+                range: [node.location.start.offset, node.location.end.offset],
+                raw: text.slice(
+                  node.location.start.offset,
+                  node.location.end.offset
+                ),
+                type: ASTNodeTypes.Str,
+                value: node.content
+              }
+            ];
+          case "arg.group":
+            return node.content.map(transform).reduce((a, b) => [...a, ...b]);
+          case "arg.optional":
+            return node.content.map(transform).reduce((a, b) => [...a, ...b]);
+          case "parbreak":
+            return [{
               loc: {
                 start: {
                   line: node.location.start.line,
@@ -411,24 +530,21 @@ export const parse = (text: string): TxtParentNode => {
                 node.location.start.offset,
                 node.location.end.offset
               ),
-              type: ASTNodeTypes.Str,
-              value: node.content
-            };
-          case "arg.group":
-            return transform(node.content[0]);
-          case "arg.optional":
-            return transform(node.content[0]);
-          case "parbreak":
+              type: ASTNodeTypes.ParagraphExit,
+              value: text.slice(
+                node.location.start.offset,
+                node.location.end.offset
+              )
+            }]
           case "ignore":
           case "alignmentTab":
           case "activeCharacter":
           case "math.character":
           case "command.def":
           case "commandParameter":
-            return null;
+            return [];
         }
       })
-      .map(n => (n !== null ? [n] : []))
-      .reduce((a, b) => a.concat(b))
+      .reduce((a, b) => [...a, ...b], [])
   });
 };

--- a/test/latex-to-ast.test.ts
+++ b/test/latex-to-ast.test.ts
@@ -8,8 +8,7 @@ describe("TxtNode AST", () => {
   test("Valid ast", () => {
     const code = `
         \\documentclass{article}
-        \\begin{document}
-        Hello
+        \\begin{document} Hello
         \\end{document}
         `;
     ASTTester.test(parse(code));
@@ -123,6 +122,12 @@ describe("Fixing document", () => {
         \\documentclass{article}
         \\begin{document}I have a pen.\\end{document}
         `;
+    const result = await kernel.fixText(input, { ...options, ext: ".tex" });
+    expect(result.output).toBe(output);
+  });
+  test("latex code outside of document environment", async () => {
+    const input = `I has a pens.`;
+    const output = `I have a pen.`;
     const result = await kernel.fixText(input, { ...options, ext: ".tex" });
     expect(result.output).toBe(output);
   });

--- a/test/latex-to-ast.test.ts
+++ b/test/latex-to-ast.test.ts
@@ -4,7 +4,7 @@ import { parse } from "../src/latex-to-ast";
 import { TextlintKernel } from "@textlint/kernel";
 
 describe("TxtNode AST", () => {
-  test("valid ast", async () => {
+  test("Valid ast", () => {
     const code = `
         \\documentclass{article}
         \\begin{document}
@@ -13,7 +13,7 @@ describe("TxtNode AST", () => {
         `;
     ASTTester.test(parse(code));
   });
-  test("parse empty comment", async () => {
+  test("Parse empty comment", () => {
     const code = `\\begin{document}
         %
         hoge%
@@ -21,19 +21,28 @@ describe("TxtNode AST", () => {
         `;
     ASTTester.test(parse(code));
   });
-  test("Parse display math", async () => {
+  test("Parse display math", () => {
     const code = `\\begin{equation}
           x^2 - 6x + 1 = 0
         \\end{equation}
         `;
     ASTTester.test(parse(code));
   });
-  test("Parse inline math", async () => {
+  test("Parse inline math", () => {
     const code = `\\begin{document}
           $x^2 = 4$
         \\end{document}
         `;
     ASTTester.test(parse(code));
+  });
+  test("Parse document", () => {
+    const code = `\\documentclass{article}
+      \\begin{document}
+      Hello
+      \\end{document}
+      `;
+    ASTTester.test(parse(code));
+    expect(parse(code).raw).toBe(code);
   });
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -627,11 +627,6 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.7.7.tgz#1628e6461ba8cc9b53196dfeaeec7b07fa6eea99"
   integrity sha512-Uo4chgKbnPNlxQwoFmYIwctkQVkMMmsAoGGU4JKwLuvBefF0pCq4FybNSnfkfRCpC7ZW7kttcC/TrRtAJsvGtg==
 
-"@types/parsimmon@^1.10.1":
-  version "1.10.1"
-  resolved "https://registry.yarnpkg.com/@types/parsimmon/-/parsimmon-1.10.1.tgz#d46015ad91128fce06a1a688ab39a2516507f740"
-  integrity sha512-MoF2IC9oGSgArJwlxdst4XsvWuoYfNUWtBw0kpnCi6K05kV+Ecl7siEeJ40tgCbI9uqEMGQL/NlPMRv6KVkY5Q==
-
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"

--- a/yarn.lock
+++ b/yarn.lock
@@ -637,11 +637,6 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
-"@types/traverse@^0.6.32":
-  version "0.6.32"
-  resolved "https://registry.yarnpkg.com/@types/traverse/-/traverse-0.6.32.tgz#f9fdfa40cd4898deaa975a14511aec731de8235e"
-  integrity sha512-RBz2uRZVCXuMg93WD//aTS5B120QlT4lR/gL+935QtGsKHLS6sCtZBaKfWjIfk7ZXv/r8mtGbwjVIee6/3XTow==
-
 "@types/yargs-parser@*":
   version "13.1.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-13.1.0.tgz#c563aa192f39350a1d18da36c5a8da382bbd8228"


### PR DESCRIPTION
Issue37に関連してparse関数を書き換えました。TypeScriptの型推論を効かせるためにTraverseを削除して、再帰関数だけで再実装しました。Documentはbegin{document}に関係なくファイルのルートをDocumentとしてパースすることにして、begin{document}の場合はenvのノードとしてPragraphに翻訳することにしました。