### PR TITLE
Hotfix/fix undefined paragraph

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "textlint-plugin-latex2e",
   "version": "1.0.0-alpha.0",
   "description": "A textlint plugin for LaTeX2e",
-  "main": "lib/index.js",
+  "main": "lib/src/index.js",
   "scripts": {
     "lint": "eslint src/**/*.ts",
     "lint:fix": "eslint --fix src/**/*.ts",

--- a/src/latex-to-ast.ts
+++ b/src/latex-to-ast.ts
@@ -65,7 +65,8 @@ const paragraphize = (rootNode: TxtParentNode): TxtParentNode => {
       paragraph.push(node);
     }
   }
-  children.push({
+  if (paragraph.length > 0) {
+    children.push({
     loc: {
       start: {
         line: paragraph[0].loc.start.line,
@@ -83,7 +84,8 @@ const paragraphize = (rootNode: TxtParentNode): TxtParentNode => {
     ),
     type: ASTNodeTypes.Paragraph,
     children: paragraph
-  });
+    });
+  }
   return { ...rootNode, children };
 };
 


### PR DESCRIPTION
The plugin crashes if there is no newline at the end of a file as it will try to add the last paragraph that doesn't exist. Also, since tests are not excluded the file structure inside `lib` seems to have changed, so I adapted the `package.json` accordingly