### PR TITLE
Improve performance of inline math

### DIFF
--- a/src/completeBlank.ts
+++ b/src/completeBlank.ts
@@ -18,6 +18,9 @@ import calculatePosition from "./calculatePosition";
 
 const completeBlank = (text: string) => <T extends TxtNode>(node: T): T => {
   if ("children" in node) {
+    if (node.children.length === 0) {
+        return node
+    }
     const children = [];
     for (let i = 0; i < node.children.length - 1; i++) {
       const range = [node.children[i].range[1], node.children[i + 1].range[0]];

--- a/src/latex-to-ast.ts
+++ b/src/latex-to-ast.ts
@@ -283,10 +283,7 @@ const transform = (text: string) => (
           },
           range: [node.location.start.offset, node.location.end.offset],
           raw: text.slice(node.location.start.offset, node.location.end.offset),
-          value: text.slice(
-            node.content[0].location?.start.offset,
-            node.content[node.content.length - 1].location?.end.offset
-          ),
+          value: text.slice(node.location.start.offset, node.location.end.offset),
           type: ASTNodeTypes.CodeBlock,
         },
       ];
@@ -327,10 +324,7 @@ const transform = (text: string) => (
           },
           range: [node.location.start.offset, node.location.end.offset],
           raw: text.slice(node.location.start.offset, node.location.end.offset),
-          value: text.slice(
-            node.content[0].location?.start.offset,
-            node.content[node.content.length - 1].location?.end.offset
-          ),
+          value: text.slice(node.location.start.offset, node.location.end.offset),
           type: ASTNodeTypes.Code,
         },
       ];

--- a/test/latex-to-ast.test.ts
+++ b/test/latex-to-ast.test.ts
@@ -47,12 +47,17 @@ describe("TxtNode AST", () => {
     const code = `\\begin{equation}
           x^2 - 6x + 1 = 0
         \\end{equation}
+        \\[
+            x^2 -6x + 1 = 0
+        \\]
         `;
     ASTTester.test(parse(code));
   });
   test("Parse inline math", () => {
     const code = `\\begin{document}
           $x^2 = 4$
+          \\( x^2 = 4 \\)
+          \\begin{math} x^2 = 4 \\end{math}
         \\end{document}
         `;
     ASTTester.test(parse(code));


### PR DESCRIPTION
fix #48 

The value of `inlineMath` and `env.math.align` node is calculated from the entire text and the location of its children.
However, it becomes an unexpected value because latex-utensils' `math.character` node seems not to have location information itself.

```
$ cat << EOF > hoge.tex
\$ x^2 - 1 = 0 \$
EOF
$ npx luparse -i -l hoge.tex
{
  kind: 'ast.root',
  content: [
    {
      kind: 'inlineMath',
      content: [
        { kind: 'math.character', content: 'x' },
        {
          kind: 'superscript',
          arg: { kind: 'math.character', content: '2' },
          location: {
            start: { offset: 3, line: 1, column: 4 },
            end: { offset: 6, line: 1, column: 7 }
          }
        },
        { kind: 'math.character', content: '-' },
        { kind: 'math.character', content: '1' },
        { kind: 'math.character', content: '=' },
        { kind: 'math.character', content: '0' }
      ],
      location: {
        start: { offset: 0, line: 1, column: 1 },
        end: { offset: 15, line: 1, column: 16 }
      }
    },
    {
      kind: 'parbreak',
      location: {
        start: { offset: 15, line: 1, column: 16 },
        end: { offset: 16, line: 2, column: 1 }
      }
    }
  ],
  comment: undefined
}
```