### PR TITLE
Wrap elements of itemize (enumerate, description) by ListItem type

### DIFF
--- a/test/latex-to-ast.test.ts
+++ b/test/latex-to-ast.test.ts
@@ -62,6 +62,23 @@ describe("TxtNode AST", () => {
         `;
     ASTTester.test(parse(code));
   });
+  test("Parse elements of itemize, enumerate, description as ListItem", () => {
+    const code = `\\begin{document}
+    \\begin{itemize}
+      \\item item1
+      \\item item2
+      \\begin{enumerate}
+        \\item item3
+      \\end{enumerate}
+    \\end{itemize}
+    \\end{document}`;
+    const parsedAst = parse(code);
+    ASTTester.test(parsedAst);
+    expect(parsedAst.children[0].children[0].type).toBe("ListItem");
+    expect(parsedAst.children[0].children[2].type).toBe("ListItem");
+    expect(parsedAst.children[0].children[4].type).toBe("ListItem");
+    expect(parsedAst.children[0].children[4].children[0].type).toBe("ListItem");
+  });
   test("Paragraph should not be nested", () => {
     const code = `\\documentclass{article}
       \\begin{document}


### PR DESCRIPTION
fix #53 

Added `transformListItems` to set "ListItem" types to the elements of itemize/enumerate/description enviroments.
This function simply wrap  `transform(text)(node)` by a "ListItem" node.

Added a test for these environments.