### PR TITLE
Add initial values to reduce() in the "arg.group" and "arg.optional" case

### DIFF
--- a/src/latex-to-ast.ts
+++ b/src/latex-to-ast.ts
@@ -367,9 +367,9 @@ const transform = (text: string) => (
         },
       ];
     case "arg.group":
-      return node.content.map(transform(text)).reduce((a, b) => [...a, ...b]);
+      return node.content.map(transform(text)).reduce((a, b) => [...a, ...b], []);
     case "arg.optional":
-      return node.content.map(transform(text)).reduce((a, b) => [...a, ...b]);
+      return node.content.map(transform(text)).reduce((a, b) => [...a, ...b], []);
     case "parbreak":
       return [
         {


### PR DESCRIPTION
plugin-latex2e fails to parse empty braces (`{}`).

```js
  test("Parse empty", () => {
    const code = `{}`;
    ASTTester.test(parse(code));
  });
```

Such braces seem to be treated as `arg.group`.
```js
    TypeError: Reduce of empty array with no initial value
        at Array.reduce (<anonymous>)

      368 |       ];
      369 |     case "arg.group":
    > 370 |       return node.content.map(transform(text)).reduce((a, b) => [...a, ...b]);
          |                                                ^
      371 |     case "arg.optional":
      372 |       return node.content.map(transform(text)).reduce((a, b) => [...a, ...b]);
      373 |     case "parbreak":
```

Then I added initial values to reduce() in the "arg.group" and "arg.optional" case.

```diff
@@ -367,9 +367,9 @@ const transform = (text: string) => (
         },
       ];
     case "arg.group":
-      return node.content.map(transform(text)).reduce((a, b) => [...a, ...b]);
+      return node.content.map(transform(text)).reduce((a, b) => [...a, ...b], []);
     case "arg.optional":
-      return node.content.map(transform(text)).reduce((a, b) => [...a, ...b]);
+      return node.content.map(transform(text)).reduce((a, b) => [...a, ...b], []);
     case "parbreak":
       return [
         {
```