### PR TITLE
Add Maintainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Copyright (C) 2018-2020 Textlint Plugin LaTeX2e Maintainers ALL Rights Reserved.
 ## Maintainers
 
 - TANIGUCHI Masaya ([@tani](https://github.com/tani))
+- Shoma Kokuryo ([@pddg](https://github.com/pddg))
+- K Ito([@kn1cht](https://github.com/kn1cht))
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,11 @@ And add to `.textlintrc`
 
 ## Copyright
 
-Copyright (C) 2018-2020 TANIGUCHI Masaya ALL Rights Reserved.
+Copyright (C) 2018-2020 Textlint Plugin LaTeX2e Maintainers ALL Rights Reserved.
+
+## Maintainers
+
+- TANIGUCHI Masaya ([@tani](https://github.com/tani))
 
 ## License
 


### PR DESCRIPTION
Since I published v0.1.0, we received so many contributions!
I should replace "Textlint Plugin LaTeX2e Maintainers" as the copyright holders because this code is not written by my hands only.

However, I also have to list members who contribute the enough lines, which means that they have the copyright of this project.
At least, I will add members of this project to the list. @pddg , do you agree with me?