### PR TITLE
Fix issue58

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,13 +26,13 @@ jobs:
               run: $(npm bin)/can-npm-publish
               continue-on-error: true
             - name: Publish
-              if: steps.check_availability.conclusion == success
+              if: steps.check_availability.outcome == "success"
               uses: JS-DevTools/npm-publish@v1
               with:
                   token: ${{ secrets.NPM_TOKEN }}
             - name: Post comment
               uses: mshick/add-pr-comment@v1
-              if: steps.check_availability.conclusion == success
+              if: steps.check_availability.outcome == "success"
               with:
                   message: |
                       Thank you for your contributions!
@@ -43,7 +43,7 @@ jobs:
                   allow-repeats: false
             - name: Post comment
               uses: mshick/add-pr-comment@v1
-              if: steps.check_availability.conclusion == failure
+              if: steps.check_availability.outcome == "failure"
               with:
                   message: |
                       Thank you for your contributions!

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,9 +27,21 @@ jobs:
               id: check_availability
               run: $(npm bin)/can-npm-publish
               continue-on-error: true
+            - name: Check tag
+              id: check_tag
+              run: |
+                TAG=v$(jq -r ".version" package.json)
+                if git show-ref --tags | grep -q "refs/tags/${TAG}"
+                then
+                  echo "${TAG} exists."
+                  exit 1
+                else
+                  echo "${TAG} does not exist. It will add to this repository."
+                fi
+              continue-on-error: true
             - name: Publish
               id: npm_publish
-              if: steps.check_availability.outcome == "success"
+              if: steps.check_availability.outcome == "success" && steps.check_tag.outcome == "success"
               uses: JS-DevTools/npm-publish@v1
               with:
                   token: ${{ secrets.NPM_TOKEN }}
@@ -37,17 +49,11 @@ jobs:
               if: steps.npm_publish.conclusion == "success"
               run: |
                 TAG=v$(jq -r ".version" package.json)
-                if git show-ref --tags | grep -q "refs/tags/${TAG}"
-                then
-                  echo "${TAG} exists. Skipped."
-                  exit
-                else
-                  git tag ${TAG}
-                  git push origin --tags
-                fi
+                git tag ${TAG}
+                git push origin --tags
             - name: Post comment
               uses: mshick/add-pr-comment@v1
-              if: steps.check_availability.outcome == "success"
+              if: steps.check_availability.outcome == "success" && steps.check_tag.outcome == "success"
               with:
                   message: |
                       Thank you for your contributions!
@@ -58,7 +64,7 @@ jobs:
                   allow-repeats: false
             - name: Post comment
               uses: mshick/add-pr-comment@v1
-              if: steps.check_availability.outcome == "failure"
+              if: steps.check_availability.outcome == "failure" || steps.check_tag.outcome == "failure"
               with:
                   message: |
                       Thank you for your contributions!

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,10 +13,10 @@ jobs:
         steps:
             - name: Checkout source
               uses: actions/checkout@v2
-            - name: Use Node.js ${{ matrix.node-version }}
+            - name: Use Node.js "14.x"
               uses: actions/setup-node@v1
               with:
-                  node-version: ${{ matrix.node-version }}
+                  node-version: "14.x"
             - name: Install dependencies
               run: npm install
               env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,8 @@ jobs:
         steps:
             - name: Checkout source
               uses: actions/checkout@v2
+              with:
+                fetch-depth: -1
             - name: Use Node.js "14.x"
               uses: actions/setup-node@v1
               with:
@@ -26,10 +28,23 @@ jobs:
               run: $(npm bin)/can-npm-publish
               continue-on-error: true
             - name: Publish
+              id: npm_publish
               if: steps.check_availability.outcome == "success"
               uses: JS-DevTools/npm-publish@v1
               with:
                   token: ${{ secrets.NPM_TOKEN }}
+            - name: Tagging
+              if: steps.npm_publish.conclusion == "success"
+              run: |
+                TAG=v$(jq -r ".version" package.json)
+                if git show-ref --tags | grep -q "refs/tags/${TAG}"
+                then
+                  echo "${TAG} exists. Skipped."
+                  exit
+                else
+                  git tag ${TAG}
+                  git push origin --tags
+                fi
             - name: Post comment
               uses: mshick/add-pr-comment@v1
               if: steps.check_availability.outcome == "success"


### PR DESCRIPTION
fix #58 

## Fix

- Use the fixed version of Nodejs
- Fix unquoted string characters
- Fix condition of steps
  - Use `outcome` instead of `conclusion`.
  - `conclusion` always be `"success"` if `continue-on-error` is used.
  - https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#steps-context

## Changes

- Automated tagging
  - Fetch all histories of this repository (`fetch-depth: -1`)
  - Obtain tag name from the version of `package.json`.