### PR TITLE
Support latex-utensils 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textlint-plugin-latex2e",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "description": "A textlint plugin for LaTeX2e",
   "main": "lib/index.js",
   "scripts": {

--- a/src/latex-to-ast.ts
+++ b/src/latex-to-ast.ts
@@ -429,6 +429,28 @@ const transform = (text: string) => (
           }],
         },
       ];
+    case "command.href":
+      return [
+        {
+          loc: {
+            start: {
+              line: node.location.start.line,
+              column: node.location.start.column - 1,
+            },
+            end: {
+              line: node.location.end.line,
+              column: node.location.end.column - 1,
+            },
+          },
+          range: [node.location.start.offset, node.location.end.offset],
+          raw: text.slice(node.location.start.offset, node.location.end.offset),
+          url: node.url,
+          type: ASTNodeTypes.Link,
+          children: node.content
+            .map(transform(text))
+            .reduce((a, b) => [...a, ...b], []),
+        },
+      ];
     case "ignore":
     case "alignmentTab":
     case "activeCharacter":

--- a/src/latex-to-ast.ts
+++ b/src/latex-to-ast.ts
@@ -394,6 +394,41 @@ const transform = (text: string) => (
           type: "parbreak",
         },
       ];
+    case "command.url":
+      return [
+        {
+          loc: {
+            start: {
+              line: node.location.start.line,
+              column: node.location.start.column - 1,
+            },
+            end: {
+              line: node.location.end.line,
+              column: node.location.end.column - 1,
+            },
+          },
+          range: [node.location.start.offset, node.location.end.offset],
+          raw: text.slice(node.location.start.offset, node.location.end.offset),
+          url: node.url,
+          type: ASTNodeTypes.Link,
+          children: [{
+            loc: {
+              start: {
+                line: node.location.start.line,
+                column: node.location.start.column - 1,
+              },
+              end: {
+                line: node.location.end.line,
+                column: node.location.end.column - 1,
+              },
+            },
+            range: [node.location.start.offset, node.location.end.offset],
+            raw: text.slice(node.location.start.offset, node.location.end.offset),
+            value: node.url,
+            type: ASTNodeTypes.Str,
+          }],
+        },
+      ];
     case "ignore":
     case "alignmentTab":
     case "activeCharacter":

--- a/src/latex-to-ast.ts
+++ b/src/latex-to-ast.ts
@@ -451,6 +451,25 @@ const transform = (text: string) => (
             .reduce((a, b) => [...a, ...b], []),
         },
       ];
+    case "command.label":
+      return [
+        {
+          loc: {
+            start: {
+              line: node.location.start.line,
+              column: node.location.start.column - 1,
+            },
+            end: {
+              line: node.location.end.line,
+              column: node.location.end.column - 1,
+            },
+          },
+          range: [node.location.start.offset, node.location.end.offset],
+          raw: text.slice(node.location.start.offset, node.location.end.offset),
+          value: node.label,
+          type: ASTNodeTypes.Html,
+        },
+      ];
     case "ignore":
     case "alignmentTab":
     case "activeCharacter":

--- a/test/latex-to-ast.test.ts
+++ b/test/latex-to-ast.test.ts
@@ -192,6 +192,14 @@ C`;
     expect(actual.children[0].children[0].url).toBe("http://example.com/");
     expect(actual.children[0].children[0].children[0].value).toBe("link");
   })
+  test("label command", () => {
+    const code = `\\ref{label}`;
+    const actual = parse(code);
+    expect(actual.children.length).toBe(1);
+    expect(actual.children[0].children[0].type).toBe(ASTNodeTypes.Html);
+    expect(actual.children[0].children[0].value).toBe("label");
+    expect(actual.children[0].children[0].raw).toBe(code);
+  })
 });
 
 describe("Fixing document", () => {

--- a/test/latex-to-ast.test.ts
+++ b/test/latex-to-ast.test.ts
@@ -176,6 +176,14 @@ C`;
     expect(actual.children[0].children[0].type).toBe(ASTNodeTypes.CodeBlock);
     expect(actual.children[0].children[0].children).toBe(undefined);
   });
+  test("url command", () => {
+    const code = `\\url{http://example.com/}`;
+    const actual = parse(code);
+    expect(actual.children.length).toBe(1);
+    expect(actual.children[0].children[0].type).toBe(ASTNodeTypes.Link);
+    expect(actual.children[0].children[0].url).toBe("http://example.com/");
+    expect(actual.children[0].children[0].children[0].value).toBe("http://example.com/");
+  })
 });
 
 describe("Fixing document", () => {

--- a/test/latex-to-ast.test.ts
+++ b/test/latex-to-ast.test.ts
@@ -184,6 +184,14 @@ C`;
     expect(actual.children[0].children[0].url).toBe("http://example.com/");
     expect(actual.children[0].children[0].children[0].value).toBe("http://example.com/");
   })
+  test("href command", () => {
+    const code = `\\href{http://example.com/}{link}`;
+    const actual = parse(code);
+    expect(actual.children.length).toBe(1);
+    expect(actual.children[0].children[0].type).toBe(ASTNodeTypes.Link);
+    expect(actual.children[0].children[0].url).toBe("http://example.com/");
+    expect(actual.children[0].children[0].children[0].value).toBe("link");
+  })
 });
 
 describe("Fixing document", () => {


### PR DESCRIPTION
## Changes

- `\url{}` and `\href{}{}` are parsed as `Link`
- `\label{}` and `\ref{}` are parsed as `Html`

refs https://github.com/textlint/textlint-plugin-latex2e/pull/64#issuecomment-770181829