### PR TITLE
Add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - directory: "/"
+    open-pull-requests-limit: 5
+    package-ecosystem: "npm" 
+    rebase-strategy: auto
+    schedule:
+      interval: weekly
+      day: "saturday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+  - directory: "/"
+    open-pull-requests-limit: 5
+    package-ecosystem: "github-actions" 
+    rebase-strategy: auto
+    schedule:
+      interval: weekly
+      day: "saturday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"


### PR DESCRIPTION
refs #59 

`dependabot.yml` is needed to upgrade dependencies if the update is not a security update.
https://docs.github.com/en/github/administering-a-repository/enabling-and-disabling-version-updates

## Changes

- Add `.github/dependabot.yml`
  - Dependabot now creates PR every Saturday 09:00 JST.