### PR TITLE
Ignore parbreak in itemize

### DIFF
--- a/src/latex-to-ast.ts
+++ b/src/latex-to-ast.ts
@@ -525,12 +525,11 @@ const transform =
 const transformListItems =
   (text: string) =>
   (node: latexParser.Node): (TxtTextNode | TxtNode)[] => {
-    if (
-      (node.kind === "command" && node.name === "item") ||
-      node.kind === "math.character"
-    ) {
+    if (node.kind === "math.character" || node.kind === "parbreak") {
       return [];
     }
+    const isItemCommand = node.kind === "command" && node.name === "item";
+    const nodeType = isItemCommand ? ASTNodeTypes.Html : ASTNodeTypes.ListItem;
     return [
       {
         loc: {
@@ -545,7 +544,7 @@ const transformListItems =
         },
         range: [node.location.start.offset, node.location.end.offset],
         raw: text.slice(node.location.start.offset, node.location.end.offset),
-        type: ASTNodeTypes.ListItem,
+        type: nodeType,
         children: transform(text)(node),
       },
     ];

--- a/test/latex-to-ast.test.ts
+++ b/test/latex-to-ast.test.ts
@@ -85,10 +85,10 @@ describe("TxtNode AST", () => {
     \\end{document}`;
     const parsedAst = parse(code);
     ASTTester.test(parsedAst);
-    expect(parsedAst.children[0].children[0].type).toBe("ListItem");
     expect(parsedAst.children[0].children[2].type).toBe("ListItem");
-    expect(parsedAst.children[0].children[4].type).toBe("ListItem");
-    expect(parsedAst.children[0].children[4].children[0].type).toBe("ListItem");
+    expect(parsedAst.children[0].children[6].type).toBe("ListItem");
+    expect(parsedAst.children[0].children[8].type).toBe("ListItem");
+    expect(parsedAst.children[0].children[8].children[2].type).toBe("ListItem");
   });
   test("Paragraph should not be nested", () => {
     const code = `\\documentclass{article}
@@ -234,6 +234,27 @@ fugafuga`;
     const actual = parse(code);
     expect(actual.children.length).toBe(1);
     expect(actual.children[0].type).toBe(ASTNodeTypes.Paragraph);
+  });
+  test("comments with blank lines should be allowed in itemize environment", () => {
+    const code = `\\begin{itemize}
+  \\item item1
+
+  % comment
+  \\item item2
+\\end{itemize}`;
+    const actual = parse(code);
+    expect(actual.children.length).toBe(1);
+    expect(actual.children[0].type).toBe(ASTNodeTypes.Paragraph);
+    expect(actual.children[0].children[2].type).toBe(ASTNodeTypes.ListItem);
+    expect(actual.children[0].children[3].type).toBe(ASTNodeTypes.Html);
+    expect(actual.children[0].children[4].type).toBe(ASTNodeTypes.Comment);
+    // actual.children[0].children[5] is a linebreak and whitespace after the comment.
+    expect(actual.children[0].children[5].type).toBe(ASTNodeTypes.Html);
+    // actual.children[0].children[6] is the second \item.
+    expect(actual.children[0].children[6].type).toBe(ASTNodeTypes.Html);
+    // actual.children[0].children[7] is a whitespace after the second \item.
+    expect(actual.children[0].children[7].type).toBe(ASTNodeTypes.Html);
+    expect(actual.children[0].children[8].type).toBe(ASTNodeTypes.ListItem);
   });
 });
 


### PR DESCRIPTION
fix #158 

### Changes

- Ignoring `parbreak` in itemize, enumerate, and description.
- Keep consistency of parsing behavior.

Until now, the first `\item` command has been ignored (It was included in the parent element's `raw` and the resulting behavior seemed fine). On the other hand, the second and subsequent `\item` commands were parsed and existed as nodes whose type is `ASTNodeTypes.Html`.
I have made changes to make the behavior more consistent. With this change, all `\item` commands will be parsed as node whose type is `ASTNodeTypes.Html`.