### PR TITLE
Remove publish workflow PR comments

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,8 +12,6 @@ jobs:
         if: github.event.pull_request.merged == true
         permissions:
             contents: write
-            issues: write
-            pull-requests: write
         steps:
             - name: Checkout source
               uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -56,23 +54,3 @@ jobs:
                 TAG=v$(jq -r ".version" package.json)
                 git tag ${TAG}
                 git push origin --tags
-            - name: Post comment
-              if: steps.check_availability.outcome == 'success' && steps.check_tag.outcome == 'success'
-              env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: |
-                  gh pr comment "${{ github.event.pull_request.number }}" --edit-last --create-if-none --body-file - <<'EOF'
-                  Thank you for your contributions!
-                  We publish new version of this package.
-                  Cheers!
-                  EOF
-            - name: Post comment
-              if: steps.check_availability.outcome == 'failure' || steps.check_tag.outcome == 'failure'
-              env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              run: |
-                  gh pr comment "${{ github.event.pull_request.number }}" --edit-last --create-if-none --body-file - <<'EOF'
-                  Thank you for your contributions!
-                  We include your contributions in next release.
-                  Cheers!
-                  EOF


### PR DESCRIPTION
## Summary

This PR makes the PR comment steps in the publish workflow best-effort.

After #471 was merged, the publish workflow failed while trying to post the follow-up PR comment:

```text
GraphQL: Resource not accessible by integration (addComment)
```

The merged PR came from a fork, so the `GITHUB_TOKEN` available to the `pull_request` workflow did not have permission to create or edit PR comments, even though the workflow declares write permissions. In contrast, the later Renovate PR #472  was created from a branch in this repository, so the same comment step succeeded there.

<img width="684" height="290" alt="image" src="https://github.com/user-attachments/assets/6fa4eca5-cdbc-4003-86e8-05ebc1b754cf" />

Since these comments are only supplemental notifications and should not determine whether the publish workflow succeeds, this PR adds `continue-on-error: true` to both `gh pr comment` steps.

## Checks

- Parsed `.github/workflows/publish.yml` locally as YAML